### PR TITLE
Return false if no keyword matches

### DIFF
--- a/lib/ruboty/handlers/response.rb
+++ b/lib/ruboty/handlers/response.rb
@@ -14,11 +14,15 @@ module Ruboty
       def catchall(message)
         return if message.from_name == robot.name
 
+        matched = false
         responses.each do |id, hash|
           next unless message[:keyword] =~ /#{hash[:regex]}/ rescue false
 
+          matched = true
           message.reply(hash[:response])
         end
+
+        matched
       rescue => e
         Ruboty.logger.error("Error: #{e.class}: #{e.message}}")
       end


### PR DESCRIPTION
Make `Ruboty::Handlers::Response#catchall` return false if no keyword matches.
When `Ruboty::Handlers::Response#catchall` returns false, it means the message is not handled yet and missing handlers (such as https://github.com/tomoasleep/ruboty-openai_chat) can respond to the message.